### PR TITLE
fix: fix swap gate on Python version

### DIFF
--- a/micromoth.py
+++ b/micromoth.py
@@ -180,10 +180,10 @@ def simulate(qc,shots=1024,get='counts',noise_model=[]):
             theta = gate[1]
             k[b0],k[b1]=phaseturn(k[b0],k[b1],theta) 
     
-    elif gate[0] in ['cx','crx']: # These are the only two qubit gates recognized by the simulator.
+    elif gate[0] in ['cx','crx', 'swap']:
       
       # Get the source and target qubits
-      if gate[0]=='cx': 
+      if gate[0] in ['cx', 'swap']: 
         [s,t] = gate[1:]
       else:
         theta = gate[1]

--- a/versions/Python/initialize_micromoth.py
+++ b/versions/Python/initialize_micromoth.py
@@ -111,6 +111,35 @@ def test_cx():
     qc.cx(0,1)
     assert( simulate(qc,shots=shots,get='statevector')==[[0.0, 0.0], [0.0, 0.0], [1.0, 0.0], [0.0, 0.0]] )
 
+
+def test_swap00():
+    qc = QuantumCircuit(2)
+    assert( simulate(qc,shots=shots,get='statevector')==[[1.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]] )
+    qc.swap(0,1)
+    assert( simulate(qc,shots=shots,get='statevector')==[[1.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]] )
+
+def test_swap01():
+    qc = QuantumCircuit(2)
+    qc.x(0)
+    assert( simulate(qc,shots=shots,get='statevector')==[[0.0, 0.0], [1.0, 0.0], [0.0, 0.0], [0.0, 0.0]] )
+    qc.swap(0,1)
+    assert( simulate(qc,shots=shots,get='statevector')==[[0.0, 0.0], [0.0, 0.0], [1.0, 0.0], [0.0, 0.0]] )
+
+def test_swap10():
+    qc = QuantumCircuit(2)
+    qc.x(1)
+    assert( simulate(qc,shots=shots,get='statevector')==[[0.0, 0.0], [0.0, 0.0], [1.0, 0.0], [0.0, 0.0]] )
+    qc.swap(0,1)
+    assert( simulate(qc,shots=shots,get='statevector')==[[0.0, 0.0], [1.0, 0.0], [0.0, 0.0], [0.0, 0.0]] )
+
+def test_swap11():
+    qc = QuantumCircuit(2)
+    qc.x(0)
+    qc.x(1)
+    assert( simulate(qc,shots=shots,get='statevector')==[[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [1.0, 0.0]] )
+    qc.swap(0,1)
+    assert( simulate(qc,shots=shots,get='statevector')==[[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [1.0, 0.0]] )
+
 def test_memory():
     qc = QuantumCircuit(2,2)
     qc.h(0)
@@ -223,5 +252,9 @@ test_counts()
 test_add()
 test_multiqubit()
 test_noise ()
+test_swap00()
+test_swap01()
+test_swap10()
+test_swap11()
 
 print('Tests passed!')

--- a/versions/Python/micromoth.py
+++ b/versions/Python/micromoth.py
@@ -88,8 +88,8 @@ def simulate(qc,shots=1024,get='counts',noise_model=[]):
           elif gate[0]=='rz': 
             theta = gate[1]
             k[b0],k[b1]=phaseturn(k[b0],k[b1],theta) 
-    elif gate[0] in ['cx','crx']: 
-      if gate[0]=='cx': 
+    elif gate[0] in ['cx','crx', 'swap']:
+      if gate[0] in ['cx', 'swap']: 
         [s,t] = gate[1:]
       else:
         theta = gate[1]


### PR DESCRIPTION
# Fix for issue #13 

## The problem
SWAP gate wasn't working in the python version of MicroMoth.

## The fix
The `'swap'` string was added to the list of two Qubit gates inside the `simulate` function.

## What was changed?

* 4 more tests were added to ensure that the SWAP gate is now working properly
* both `micromoth.py` files were changed due to [the fix](#the-fix) 

