### PR TITLE
refactor: SWAP and CRX as non-compiled gates for Lua version

### DIFF
--- a/versions/Lua/MicroMoth.lua
+++ b/versions/Lua/MicroMoth.lua
@@ -97,9 +97,7 @@ function QuantumCircuit ()
   end
 
   function qc.swap (s,t)
-    qc.cx(s,t)
-    qc.cx(t,s)
-    qc.cx(s,t)
+    qc.data[#qc.data+1] = ( {'swap',s,t} )
   end
 
   return qc
@@ -189,7 +187,7 @@ function simulate (qc, get, shots)
         end
       end
 
-    elseif gate[1]=="cx" then
+    elseif gate[1]=="cx" or gate[1] == "swap" then
 
       s = gate[2]
       t = gate[3]
@@ -205,11 +203,18 @@ function simulate (qc, get, shots)
       for i0=0,2^l-1 do
         for i1=0,2^(h-l-1)-1 do
           for i2=0,2^(qc.num_qubits-h-1)-1 do
-            b1 = i0 + 2^(l+1)*i1 + 2^(h+1)*i2 + 2^s + 1
-            b2 = b1 + 2^t
-            e = {{ket[b1][1],ket[b1][2]},{ket[b2][1],ket[b2][2]}}
-            ket[b1] = e[2]
-            ket[b2] = e[1]
+            b1 = i0 + 2^(l+1)*i1 + 2^(h+1)*i2 + 2^s + 1 --01
+	    b2 = b1 + 2^t --11
+	    b3 = b2 - 2^s
+            if gate[1] == "cx" then 
+		    e = {{ket[b1][1],ket[b1][2]},{ket[b2][1],ket[b2][2]}}
+		    ket[b1] = e[2]
+		    ket[b2] = e[1]
+	    elseif gate[1] == "swap" then
+		    e = {{ket[b1][1],ket[b1][2]},{ket[b3][1],ket[b3][2]}}
+		    ket[b1] = e[2]
+		    ket[b3] = e[1]
+	    end
           end
         end
       end

--- a/versions/Lua/MicroMoth.lua
+++ b/versions/Lua/MicroMoth.lua
@@ -89,12 +89,6 @@ function QuantumCircuit ()
 
   function qc.crx (theta,s,t)
     qc.data[#qc.data+1] = ( {'crx',s,t,theta} )
-    -- qc.rx(theta/2,t)
-    -- qc.h(t)
-    -- qc.cx(s,t)
-    -- qc.rz(-theta/2,t)
-    -- qc.cx(s,t)
-    -- qc.h(t)
   end
 
   function qc.swap (s,t)

--- a/versions/Lua/MicroMoth.lua
+++ b/versions/Lua/MicroMoth.lua
@@ -201,8 +201,8 @@ function simulate (qc, get, shots)
       for i0=0,2^l-1 do
         for i1=0,2^(h-l-1)-1 do
           for i2=0,2^(qc.num_qubits-h-1)-1 do
-            b1 = i0 + 2^(l+1)*i1 + 2^(h+1)*i2 + 2^s + 1 --01
-	    b2 = b1 + 2^t --11
+            b1 = i0 + 2^(l+1)*i1 + 2^(h+1)*i2 + 2^s + 1
+	    b2 = b1 + 2^t
 	    b3 = b2 - 2^s
 	    e = {{ket[b1][1],ket[b1][2]},{ket[b2][1],ket[b2][2]}}
             if gate[1] == "cx" then 

--- a/versions/Lua/tests.lua
+++ b/versions/Lua/tests.lua
@@ -1,0 +1,84 @@
+
+dofile("MicroMoth.lua")
+
+function test_swap00 ()
+	local qc = QuantumCircuit()
+	local statevec, is_desired_state, has_no_phase
+
+	qc.set_registers(2)
+	statevec = simulate(qc, "statevector")
+	is_desired_state = statevec[1][1] == 1 and statevec[2][1] == 0 and statevec[3][1] == 0 and statevec[4][1] == 0
+	has_no_phase = statevec[1][2] == 0 and statevec[2][2] == 0 and statevec[3][2] == 0 and statevec[4][2] == 0
+	assert(is_desired_state and has_no_phase , "Invalid Initial State for SWAP 00")
+	
+	qc.swap(0,1)
+	statevec = simulate(qc, "statevector")
+	is_desired_state = statevec[1][1] == 1 and statevec[2][1] == 0 and statevec[3][1] == 0 and statevec[4][1] == 0
+	has_no_phase = statevec[1][2] == 0 and statevec[2][2] == 0 and statevec[3][2] == 0 and statevec[4][2] == 0
+	assert(is_desired_state and has_no_phase , "Invalid Final State for SWAP 00")
+end
+
+function test_swap01 ()
+	local qc = QuantumCircuit()
+	local statevec, is_desired_state, has_no_phase
+
+	qc.set_registers(2)
+	qc.x(0)
+	statevec = simulate(qc, "statevector")
+	is_desired_state = statevec[1][1] == 0 and statevec[2][1] == 1 and statevec[3][1] == 0 and statevec[4][1] == 0
+	has_no_phase = statevec[1][2] == 0 and statevec[2][2] == 0 and statevec[3][2] == 0 and statevec[4][2] == 0
+	assert(is_desired_state and has_no_phase , "Invalid Initial State for SWAP 01")
+	
+	qc.swap(0,1)
+	statevec = simulate(qc, "statevector")
+	is_desired_state = statevec[1][1] == 0 and statevec[2][1] == 0 and statevec[3][1] == 1 and statevec[4][1] == 0
+	has_no_phase = statevec[1][2] == 0 and statevec[2][2] == 0 and statevec[3][2] == 0 and statevec[4][2] == 0
+	assert(is_desired_state and has_no_phase , "Invalid Final State for SWAP 01")
+end
+
+function test_swap10 ()
+	local qc = QuantumCircuit()
+	local statevec, is_desired_state, has_no_phase
+
+	qc.set_registers(2)
+	qc.x(1)
+	statevec = simulate(qc, "statevector")
+	is_desired_state = statevec[1][1] == 0 and statevec[2][1] == 0 and statevec[3][1] == 1 and statevec[4][1] == 0
+	has_no_phase = statevec[1][2] == 0 and statevec[2][2] == 0 and statevec[3][2] == 0 and statevec[4][2] == 0
+	assert(is_desired_state and has_no_phase , "Invalid Initial State for SWAP 10")
+	
+	qc.swap(0,1)
+	statevec = simulate(qc, "statevector")
+	is_desired_state = statevec[1][1] == 0 and statevec[2][1] == 1 and statevec[3][1] == 0 and statevec[4][1] == 0
+	has_no_phase = statevec[1][2] == 0 and statevec[2][2] == 0 and statevec[3][2] == 0 and statevec[4][2] == 0
+	assert(is_desired_state and has_no_phase , "Invalid Final State for SWAP 10")
+end
+
+
+function test_swap11 ()
+	local qc = QuantumCircuit()
+	local statevec, is_desired_state, has_no_phase
+
+	qc.set_registers(2)
+	qc.x(0)
+	qc.x(1)
+	statevec = simulate(qc, "statevector")
+	is_desired_state = statevec[1][1] == 0 and statevec[2][1] == 0 and statevec[3][1] == 0 and statevec[4][1] == 1
+	has_no_phase = statevec[1][2] == 0 and statevec[2][2] == 0 and statevec[3][2] == 0 and statevec[4][2] == 0
+	assert(is_desired_state and has_no_phase , "Invalid Initial State for SWAP 11")
+	
+	qc.swap(0,1)
+	statevec = simulate(qc, "statevector")
+	is_desired_state = statevec[1][1] == 0 and statevec[2][1] == 0 and statevec[3][1] == 0 and statevec[4][1] == 1
+	has_no_phase = statevec[1][2] == 0 and statevec[2][2] == 0 and statevec[3][2] == 0 and statevec[4][2] == 0
+	assert(is_desired_state and has_no_phase , "Invalid Final State for SWAP 11")
+end
+
+print("Doing Tests...")
+
+test_swap00()
+test_swap01()
+test_swap10()
+test_swap11()
+
+print("All Tests Passed!")

--- a/versions/Lua/tests.lua
+++ b/versions/Lua/tests.lua
@@ -1,6 +1,78 @@
 
 dofile("MicroMoth.lua")
 
+function test_cx00 ()
+	local qc = QuantumCircuit()
+	local statevec, is_desired_state, has_no_phase
+
+	qc.set_registers(2)
+	statevec = simulate(qc, "statevector")
+	is_desired_state = statevec[1][1] == 1 and statevec[2][1] == 0 and statevec[3][1] == 0 and statevec[4][1] == 0
+	has_no_phase = statevec[1][2] == 0 and statevec[2][2] == 0 and statevec[3][2] == 0 and statevec[4][2] == 0
+	assert(is_desired_state and has_no_phase , "Invalid Initial State for CX 00")
+	
+	qc.cx(0,1)
+	statevec = simulate(qc, "statevector")
+	is_desired_state = statevec[1][1] == 1 and statevec[2][1] == 0 and statevec[3][1] == 0 and statevec[4][1] == 0
+	has_no_phase = statevec[1][2] == 0 and statevec[2][2] == 0 and statevec[3][2] == 0 and statevec[4][2] == 0
+	assert(is_desired_state and has_no_phase , "Invalid Final State for CX 00")
+end
+
+function test_cx01 ()
+	local qc = QuantumCircuit()
+	local statevec, is_desired_state, has_no_phase
+
+	qc.set_registers(2)
+	qc.x(0)
+	statevec = simulate(qc, "statevector")
+	is_desired_state = statevec[1][1] == 0 and statevec[2][1] == 1 and statevec[3][1] == 0 and statevec[4][1] == 0
+	has_no_phase = statevec[1][2] == 0 and statevec[2][2] == 0 and statevec[3][2] == 0 and statevec[4][2] == 0
+	assert(is_desired_state and has_no_phase , "Invalid Initial State for CX 01")
+	
+	qc.cx(0,1)
+	statevec = simulate(qc, "statevector")
+	is_desired_state = statevec[1][1] == 0 and statevec[2][1] == 0 and statevec[3][1] == 0 and statevec[4][1] == 1
+	has_no_phase = statevec[1][2] == 0 and statevec[2][2] == 0 and statevec[3][2] == 0 and statevec[4][2] == 0
+	assert(is_desired_state and has_no_phase , "Invalid Final State for CX 01")
+end
+
+function test_cx10 ()
+	local qc = QuantumCircuit()
+	local statevec, is_desired_state, has_no_phase
+
+	qc.set_registers(2)
+	qc.x(1)
+	statevec = simulate(qc, "statevector")
+	is_desired_state = statevec[1][1] == 0 and statevec[2][1] == 0 and statevec[3][1] == 1 and statevec[4][1] == 0
+	has_no_phase = statevec[1][2] == 0 and statevec[2][2] == 0 and statevec[3][2] == 0 and statevec[4][2] == 0
+	assert(is_desired_state and has_no_phase , "Invalid Initial State for CX 10")
+	
+	qc.cx(0,1)
+	statevec = simulate(qc, "statevector")
+	is_desired_state = statevec[1][1] == 0 and statevec[2][1] == 0 and statevec[3][1] == 1 and statevec[4][1] == 0
+	has_no_phase = statevec[1][2] == 0 and statevec[2][2] == 0 and statevec[3][2] == 0 and statevec[4][2] == 0
+	assert(is_desired_state and has_no_phase , "Invalid Final State for CX 10")
+end
+
+function test_cx11 ()
+	local qc = QuantumCircuit()
+	local statevec, is_desired_state, has_no_phase
+
+	qc.set_registers(2)
+	qc.x(0)
+	qc.x(1)
+	statevec = simulate(qc, "statevector")
+	is_desired_state = statevec[1][1] == 0 and statevec[2][1] == 0 and statevec[3][1] == 0 and statevec[4][1] == 1
+	has_no_phase = statevec[1][2] == 0 and statevec[2][2] == 0 and statevec[3][2] == 0 and statevec[4][2] == 0
+	assert(is_desired_state and has_no_phase , "Invalid Initial State for CX 11")
+	
+	qc.cx(0,1)
+	statevec = simulate(qc, "statevector")
+	is_desired_state = statevec[1][1] == 0 and statevec[2][1] == 1 and statevec[3][1] == 0 and statevec[4][1] == 0
+	has_no_phase = statevec[1][2] == 0 and statevec[2][2] == 0 and statevec[3][2] == 0 and statevec[4][2] == 0
+	assert(is_desired_state and has_no_phase , "Invalid Final State for CX 11")
+end
+
 function test_swap00 ()
 	local qc = QuantumCircuit()
 	local statevec, is_desired_state, has_no_phase
@@ -75,6 +147,12 @@ function test_swap11 ()
 end
 
 print("Doing Tests...")
+
+
+test_cx00()
+test_cx01()
+test_cx10()
+test_cx11()
 
 test_swap00()
 test_swap01()

--- a/versions/Lua/tests.lua
+++ b/versions/Lua/tests.lua
@@ -6,11 +6,6 @@ function test_cx00 ()
 	local statevec, is_desired_state, has_no_phase
 
 	qc.set_registers(2)
-	statevec = simulate(qc, "statevector")
-	is_desired_state = statevec[1][1] == 1 and statevec[2][1] == 0 and statevec[3][1] == 0 and statevec[4][1] == 0
-	has_no_phase = statevec[1][2] == 0 and statevec[2][2] == 0 and statevec[3][2] == 0 and statevec[4][2] == 0
-	assert(is_desired_state and has_no_phase , "Invalid Initial State for CX 00")
-	
 	qc.cx(0,1)
 	statevec = simulate(qc, "statevector")
 	is_desired_state = statevec[1][1] == 1 and statevec[2][1] == 0 and statevec[3][1] == 0 and statevec[4][1] == 0
@@ -24,11 +19,6 @@ function test_cx01 ()
 
 	qc.set_registers(2)
 	qc.x(0)
-	statevec = simulate(qc, "statevector")
-	is_desired_state = statevec[1][1] == 0 and statevec[2][1] == 1 and statevec[3][1] == 0 and statevec[4][1] == 0
-	has_no_phase = statevec[1][2] == 0 and statevec[2][2] == 0 and statevec[3][2] == 0 and statevec[4][2] == 0
-	assert(is_desired_state and has_no_phase , "Invalid Initial State for CX 01")
-	
 	qc.cx(0,1)
 	statevec = simulate(qc, "statevector")
 	is_desired_state = statevec[1][1] == 0 and statevec[2][1] == 0 and statevec[3][1] == 0 and statevec[4][1] == 1
@@ -42,11 +32,6 @@ function test_cx10 ()
 
 	qc.set_registers(2)
 	qc.x(1)
-	statevec = simulate(qc, "statevector")
-	is_desired_state = statevec[1][1] == 0 and statevec[2][1] == 0 and statevec[3][1] == 1 and statevec[4][1] == 0
-	has_no_phase = statevec[1][2] == 0 and statevec[2][2] == 0 and statevec[3][2] == 0 and statevec[4][2] == 0
-	assert(is_desired_state and has_no_phase , "Invalid Initial State for CX 10")
-	
 	qc.cx(0,1)
 	statevec = simulate(qc, "statevector")
 	is_desired_state = statevec[1][1] == 0 and statevec[2][1] == 0 and statevec[3][1] == 1 and statevec[4][1] == 0
@@ -61,11 +46,6 @@ function test_cx11 ()
 	qc.set_registers(2)
 	qc.x(0)
 	qc.x(1)
-	statevec = simulate(qc, "statevector")
-	is_desired_state = statevec[1][1] == 0 and statevec[2][1] == 0 and statevec[3][1] == 0 and statevec[4][1] == 1
-	has_no_phase = statevec[1][2] == 0 and statevec[2][2] == 0 and statevec[3][2] == 0 and statevec[4][2] == 0
-	assert(is_desired_state and has_no_phase , "Invalid Initial State for CX 11")
-	
 	qc.cx(0,1)
 	statevec = simulate(qc, "statevector")
 	is_desired_state = statevec[1][1] == 0 and statevec[2][1] == 1 and statevec[3][1] == 0 and statevec[4][1] == 0
@@ -73,16 +53,27 @@ function test_cx11 ()
 	assert(is_desired_state and has_no_phase , "Invalid Final State for CX 11")
 end
 
+function test_cx_bell ()
+	local qc = QuantumCircuit()
+	local statevec, is_desired_state, has_no_phase
+	
+	local half_prob = 1/math.sqrt(2)
+
+	qc.set_registers(2)
+	qc.h(1)
+	qc.cx(1,0)
+	statevec = simulate(qc, "statevector")
+	is_desired_state = statevec[1][1] == half_prob and statevec[2][1] == 0 and statevec[3][1] == 0 and statevec[4][1] == half_prob
+	has_no_phase = statevec[1][2] == 0 and statevec[2][2] == 0 and statevec[3][2] == 0 and statevec[4][2] == 0
+	assert(is_desired_state and has_no_phase , "Invalid Final State for CX Bell")
+
+end
+
 function test_swap00 ()
 	local qc = QuantumCircuit()
 	local statevec, is_desired_state, has_no_phase
 
 	qc.set_registers(2)
-	statevec = simulate(qc, "statevector")
-	is_desired_state = statevec[1][1] == 1 and statevec[2][1] == 0 and statevec[3][1] == 0 and statevec[4][1] == 0
-	has_no_phase = statevec[1][2] == 0 and statevec[2][2] == 0 and statevec[3][2] == 0 and statevec[4][2] == 0
-	assert(is_desired_state and has_no_phase , "Invalid Initial State for SWAP 00")
-	
 	qc.swap(0,1)
 	statevec = simulate(qc, "statevector")
 	is_desired_state = statevec[1][1] == 1 and statevec[2][1] == 0 and statevec[3][1] == 0 and statevec[4][1] == 0
@@ -96,11 +87,6 @@ function test_swap01 ()
 
 	qc.set_registers(2)
 	qc.x(0)
-	statevec = simulate(qc, "statevector")
-	is_desired_state = statevec[1][1] == 0 and statevec[2][1] == 1 and statevec[3][1] == 0 and statevec[4][1] == 0
-	has_no_phase = statevec[1][2] == 0 and statevec[2][2] == 0 and statevec[3][2] == 0 and statevec[4][2] == 0
-	assert(is_desired_state and has_no_phase , "Invalid Initial State for SWAP 01")
-	
 	qc.swap(0,1)
 	statevec = simulate(qc, "statevector")
 	is_desired_state = statevec[1][1] == 0 and statevec[2][1] == 0 and statevec[3][1] == 1 and statevec[4][1] == 0
@@ -114,11 +100,6 @@ function test_swap10 ()
 
 	qc.set_registers(2)
 	qc.x(1)
-	statevec = simulate(qc, "statevector")
-	is_desired_state = statevec[1][1] == 0 and statevec[2][1] == 0 and statevec[3][1] == 1 and statevec[4][1] == 0
-	has_no_phase = statevec[1][2] == 0 and statevec[2][2] == 0 and statevec[3][2] == 0 and statevec[4][2] == 0
-	assert(is_desired_state and has_no_phase , "Invalid Initial State for SWAP 10")
-	
 	qc.swap(0,1)
 	statevec = simulate(qc, "statevector")
 	is_desired_state = statevec[1][1] == 0 and statevec[2][1] == 1 and statevec[3][1] == 0 and statevec[4][1] == 0
@@ -134,16 +115,92 @@ function test_swap11 ()
 	qc.set_registers(2)
 	qc.x(0)
 	qc.x(1)
-	statevec = simulate(qc, "statevector")
-	is_desired_state = statevec[1][1] == 0 and statevec[2][1] == 0 and statevec[3][1] == 0 and statevec[4][1] == 1
-	has_no_phase = statevec[1][2] == 0 and statevec[2][2] == 0 and statevec[3][2] == 0 and statevec[4][2] == 0
-	assert(is_desired_state and has_no_phase , "Invalid Initial State for SWAP 11")
-	
 	qc.swap(0,1)
 	statevec = simulate(qc, "statevector")
 	is_desired_state = statevec[1][1] == 0 and statevec[2][1] == 0 and statevec[3][1] == 0 and statevec[4][1] == 1
 	has_no_phase = statevec[1][2] == 0 and statevec[2][2] == 0 and statevec[3][2] == 0 and statevec[4][2] == 0
 	assert(is_desired_state and has_no_phase , "Invalid Final State for SWAP 11")
+end
+
+
+function test_rx0()
+	local qc = QuantumCircuit()
+	local statevec, is_desired_state, has_desired_phase
+
+	qc.set_registers(1)
+	qc.rx(math.pi/4, 0)
+	statevec = simulate(qc, "statevector")
+	-- tostring here is used due to some unexpected error when checking two equal floating point numbers
+	is_desired_state = tostring(statevec[1][1]) == "0.92387953251129" and tostring(statevec[2][1]) == "0.0"
+	has_desired_phase = tostring(statevec[1][2]) == "0.0" and tostring(statevec[2][2]) == "-0.38268343236509"
+	assert(is_desired_state and has_desired_phase , "Invalid Final State for RX 0")
+
+end
+
+function test_rx1()
+	local qc = QuantumCircuit()
+	local statevec, is_desired_state, has_desired_phase
+
+	qc.set_registers(1)
+	qc.x(0)
+	qc.rx(math.pi/4, 0)
+	statevec = simulate(qc, "statevector")
+	-- tostring here is used due to some unexpected error when checking two equal floating point numbers
+	is_desired_state = tostring(statevec[1][1]) == "0.0" and tostring(statevec[2][1]) == "0.92387953251129"
+	has_desired_phase = tostring(statevec[1][2]) == "-0.38268343236509" and tostring(statevec[2][2]) == "0.0"
+	assert(is_desired_state and has_desired_phase , "Invalid Final State for RX 1")
+end
+
+function test_crx00()
+	local qc = QuantumCircuit()
+	local statevec, is_desired_state, has_no_phase
+
+	qc.set_registers(2)
+	qc.crx(math.pi/4, 0, 1)
+	statevec = simulate(qc, "statevector")
+	is_desired_state = statevec[1][1] == 1 and statevec[2][1] == 0 and statevec[3][1] == 0 and statevec[4][1] == 0
+	has_no_phase = statevec[1][2] == 0 and statevec[2][2] == 0 and statevec[3][2] == 0 and statevec[4][2] == 0
+	assert(is_desired_state and has_no_phase , "Invalid Final State for CRX 00")
+end
+
+function test_crx01()
+	local qc = QuantumCircuit()
+	local statevec, is_desired_state, has_desired_phase
+
+	qc.set_registers(2)
+	qc.x(0)
+	qc.crx(math.pi/4, 0, 1)
+	statevec = simulate(qc, "statevector")
+	is_desired_state = statevec[1][1] == 0 and tostring(statevec[2][1]) == "0.92387953251129" and statevec[3][1] == 0 and tostring(statevec[4][1]) == "0.0"
+	has_desired_phase = statevec[1][2] == 0 and tostring(statevec[2][2]) == "0.0" and statevec[3][2] == 0 and tostring(statevec[4][2]) == "-0.38268343236509"
+	assert(is_desired_state and has_desired_phase , "Invalid Final State for CRX 01")
+end
+
+function test_crx10()
+	local qc = QuantumCircuit()
+	local statevec, is_desired_state, has_no_phase
+
+	qc.set_registers(2)
+	qc.x(1)
+	qc.crx(math.pi/4, 0, 1)
+	statevec = simulate(qc, "statevector")
+	is_desired_state = statevec[1][1] == 0 and statevec[2][1] == 0 and statevec[3][1] == 1 and statevec[4][1] == 0
+	has_no_phase = statevec[1][2] == 0 and statevec[2][2] == 0 and statevec[3][2] == 0 and statevec[4][2] == 0
+	assert(is_desired_state and has_no_phase , "Invalid Final State for CRX 10")
+end
+
+function test_crx11()
+	local qc = QuantumCircuit()
+	local statevec, is_desired_state, has_desired_phase
+
+	qc.set_registers(2)
+	qc.x(0)
+	qc.x(1)
+	qc.crx(math.pi/4, 0, 1)
+	statevec = simulate(qc, "statevector")
+	is_desired_state = statevec[1][1] == 0 and tostring(statevec[2][1]) == "0.0" and statevec[3][1] == 0 and tostring(statevec[4][1]) == "0.92387953251129"
+	has_desired_phase = statevec[1][2] == 0 and tostring(statevec[2][2]) == "-0.38268343236509" and statevec[3][2] == 0 and tostring(statevec[4][2]) == "0.0"
+	assert(is_desired_state and has_desired_phase , "Invalid Final State for CRX 11")
 end
 
 print("Doing Tests...")
@@ -154,9 +211,20 @@ test_cx01()
 test_cx10()
 test_cx11()
 
+test_cx_bell()
+
 test_swap00()
 test_swap01()
 test_swap10()
 test_swap11()
+
+test_rx0()
+test_rx1()
+
+test_crx00()
+test_crx01()
+test_crx10()
+test_crx11()
+
 
 print("All Tests Passed!")


### PR DESCRIPTION
I implemented the `SWAP` and `CRX` gates as fundamental ones for the Lua version of MicroMoth #3.

I added some tests as well, but I'm not completely sure if these will work in every possible case.

## What was changed?

* a `tests` file was added to test: `RX`, `CRX`, `CX` and `SWAP` gates
* a `turn` function was added to implement `RX` rotation, affecting both `RX` and `CRX` implementation (as done on Python version)
* updated functions for `CRX` and `SWAP` to ensure that they will act as non-compiled gates, being applied only during the simulation step

